### PR TITLE
build-ci/manifests: the workaround is not needed anymore

### DIFF
--- a/.github/build-ci/manifests/gcc-ad.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-ad.spack.yaml.j2
@@ -2,11 +2,6 @@ spack:
   specs:
   - issm @git.{{ ref }} +wrappers +ad
   packages:
-    # Workaround due to https://github.com/spack/spack-packages/pull/3644
-    re2c:
-      require:
-      - '@3.1'
-
     gcc:
       require:
       - '@{{ gcc_compiler_version }}'

--- a/.github/build-ci/manifests/gcc-no-ad.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-no-ad.spack.yaml.j2
@@ -2,11 +2,6 @@ spack:
   specs:
   - issm @git.{{ ref }} +wrappers ~ad
   packages:
-    # Workaround due to https://github.com/spack/spack-packages/pull/3644
-    re2c:
-      require:
-      - '@3.1'
-
     gcc:
       require:
       - '@{{ gcc_compiler_version }}'


### PR DESCRIPTION
https://github.com/spack/spack-packages/pull/3644 has been merged. So the workaround should not be needed any more.